### PR TITLE
DRYD-1213: Add descriptionLevel

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -52,6 +52,7 @@ const template = (configContext) => {
               </Col>
             </Row>
 
+            <Field name="descriptionLevel" />
             <Field name="recordStatus" />
 
             <Field name="catalogLevel" subpath="ns2:collectionobjects_fineart" />


### PR DESCRIPTION
**What does this do?**
* Add descriptionLevel to default collectionobject form

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1213

Field was in OHC profile and requested to be brought into fcart

**How should this be tested? Do these changes have associated tests?**
- Rebuild and run collectionspace
- Bring in the latest changes from cspace-ui.js into your node_modules
- Run the devserver
- Create a collectionobject with an apparel size(s)
- Reload the collectionobject to ensure the save completed successfully

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested that the field saves and loads 