### PR TITLE
Add controlled fields to collectionobject

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -108,6 +108,7 @@ const template = (configContext) => {
         <Field name="objectNameList">
           <Field name="objectNameGroup">
             <Field name="objectName" />
+            <Field name="objectNameControlled" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />
@@ -212,6 +213,7 @@ const template = (configContext) => {
         <Field name="materialGroupList">
           <Field name="materialGroup">
             <Field name="material" />
+            <Field name="materialControlled" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />
             <Field name="materialName" />

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -312,6 +312,10 @@ const template = (configContext) => {
                 </Field>
               </Field>
 
+              <Field name="contentEvents">
+                <Field name="contentEvent" />
+              </Field>
+
               <Field name="contentOtherGroupList">
                 <Field name="contentOtherGroup">
                   <Field name="contentOther" />
@@ -466,10 +470,9 @@ const template = (configContext) => {
                 <Field name="assocEventNameType" />
               </InputTable>
 
-              <InputTable name="assocControlledEvent">
+              <Field name="assocEvents">
                 <Field name="assocEvent" />
-                <Field name="assocEventType" />
-              </InputTable>
+              </Field>
 
               <Field name="assocEventOrganizations">
                 <Field name="assocEventOrganization" />


### PR DESCRIPTION
**What does this do?**
* Update assocEvent to be repeatable
* Remove assocEventType
* Add controlled object name
* Add controlled material
* Add controlled contentEvent

**Why are we doing this? (with JIRA link)**
Changes requested for assocEvent, including adding contentEvent. Controlled object name and material were missing from previous work.

Assoc event, content event jira: https://collectionspace.atlassian.net/browse/DRYD-1238
Controlled object name: https://collectionspace.atlassian.net/browse/DRYD-1128
Controlled material: https://collectionspace.atlassian.net/browse/DRYD-1167

**How should this be tested? Do these changes have associated tests?**
* Build cspace with fcart enabled
* Run the devserver
* Test that the objectNameControlled field can use `concept/nomenclature`
* Test that the materialControlled field can use `concept/material`
* Test that assocEvent is repeatable and can use `chronology/event` and `chronology/era`
* Test that contentEvent is repeatable and can use `chronology/event` and `chronology/era`

**Dependencies for merging? Releasing to production?**
Application layer and cspace-ui PRs are required

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested locally