### PR TITLE
DRYD-1217: Disable archaeological place authority

### DIFF
--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -4,6 +4,7 @@ import intake from './intake';
 import conditioncheck from './conditioncheck';
 import concept from './concept';
 import movement from './movement';
+import place from './place';
 
 export default [
   collectionobject,
@@ -12,4 +13,5 @@ export default [
   intake,
   concept,
   movement,
+  place,
 ];

--- a/src/plugins/recordTypes/place/index.js
+++ b/src/plugins/recordTypes/place/index.js
@@ -1,0 +1,9 @@
+import vocabularies from './vocabularies';
+
+export default () => ({
+  recordTypes: {
+    place: {
+      vocabularies,
+    },
+  },
+});

--- a/src/plugins/recordTypes/place/vocabularies.js
+++ b/src/plugins/recordTypes/place/vocabularies.js
@@ -1,0 +1,5 @@
+export default {
+  archaeological: {
+    disabled: true,
+  },
+};


### PR DESCRIPTION
**What does this do?**
Disables the archaeological site place authority 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1217

The archaeological site is only needed for core and anthro, so it's being disabled in other profiles.

**How should this be tested? Do these changes have associated tests?**
* Build cspace with the fcart profile enabled
* Run the devserver
* Verify that the archaeological site is not visible when trying to create a place authority

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance