### PR TITLE
Update Layouts For Multiline Notes

### DIFF
--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -79,11 +79,15 @@ const template = (configContext) => {
 
         <Field name="approvalGroupList">
           <Field name="approvalGroup">
-            <Field name="approvalGroup" />
-            <Field name="approvalIndividual" />
-            <Field name="approvalStatus" />
-            <Field name="approvalDate" />
-            <Field name="approvalNote" />
+            <Panel>
+              <Row>
+                <Field name="approvalGroup" />
+                <Field name="approvalIndividual" />
+                <Field name="approvalStatus" />
+                <Field name="approvalDate" />
+              </Row>
+              <Field name="approvalNote" />
+            </Panel>
           </Field>
         </Field>
         <Field name="acquisitionNote" />

--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -246,10 +246,14 @@ const template = (configContext) => {
 
         <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
           <Field name="annotationGroup">
-            <Field name="annotationType" />
-            <Field name="annotationNote" />
-            <Field name="annotationDate" />
-            <Field name="annotationAuthor" />
+            <Panel>
+              <Row>
+                <Field name="annotationType" />
+                <Field name="annotationDate" />
+                <Field name="annotationAuthor" />
+              </Row>
+              <Field name="annotationNote" />
+            </Panel>
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -263,10 +263,14 @@ const template = (configContext) => {
 
         <Field name="annotationGroupList" subpath="ns2:collectionobjects_annotation">
           <Field name="annotationGroup">
-            <Field name="annotationType" />
-            <Field name="annotationNote" />
-            <Field name="annotationDate" />
-            <Field name="annotationAuthor" />
+            <Panel>
+              <Row>
+                <Field name="annotationType" />
+                <Field name="annotationDate" />
+                <Field name="annotationAuthor" />
+              </Row>
+              <Field name="annotationNote" />
+            </Panel>
           </Field>
         </Field>
 

--- a/src/plugins/recordTypes/intake/forms/default.jsx
+++ b/src/plugins/recordTypes/intake/forms/default.jsx
@@ -46,11 +46,15 @@ const template = (configContext) => {
 
         <Field name="approvalGroupList">
           <Field name="approvalGroup">
-            <Field name="approvalGroup" />
-            <Field name="approvalIndividual" />
-            <Field name="approvalStatus" />
-            <Field name="approvalDate" />
-            <Field name="approvalNote" />
+            <Panel>
+              <Row>
+                <Field name="approvalGroup" />
+                <Field name="approvalIndividual" />
+                <Field name="approvalStatus" />
+                <Field name="approvalDate" />
+              </Row>
+              <Field name="approvalNote" />
+            </Panel>
           </Field>
         </Field>
 


### PR DESCRIPTION
**What does this do?**
* Update the annotation group to allow for multiline notes

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1284
Jira: https://collectionspace.atlassian.net/browse/DRYD-1285

This allows the `annotationNote` to be more useful in practice as users will be able to add useful information to the field. 

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Go to create a new procedure (acquisition, collectionobject, intake) with the new layout see the annotation group with multiline input for the note
* Create the new procedure with the annotation group fields filled out and verify it saves/reloads

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance