### PR TITLE
DRYD-1397: Add controlled object and material and fix ordering

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -106,8 +106,8 @@ const template = (configContext) => {
 
         <Field name="objectNameList">
           <Field name="objectNameGroup">
-            <Field name="objectName" />
             <Field name="objectNameControlled" />
+            <Field name="objectName" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
             <Field name="objectNameSystem" />
@@ -221,8 +221,8 @@ const template = (configContext) => {
 
         <Field name="materialGroupList">
           <Field name="materialGroup">
-            <Field name="material" />
             <Field name="materialControlled" />
+            <Field name="material" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />
             <Field name="materialName" />

--- a/src/plugins/recordTypes/collectionobject/forms/public.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/public.jsx
@@ -62,6 +62,7 @@ const template = (configContext) => {
 
         <Field name="objectNameList">
           <Field name="objectNameGroup">
+            <Field name="objectNameControlled" />
             <Field name="objectName" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
@@ -83,6 +84,7 @@ const template = (configContext) => {
 
         <Field name="materialGroupList">
           <Field name="materialGroup">
+            <Field name="materialControlled" />
             <Field name="material" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />

--- a/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/timebased.jsx
@@ -89,6 +89,7 @@ const template = (configContext) => {
 
         <Field name="objectNameList">
           <Field name="objectNameGroup">
+            <Field name="objectNameControlled" />
             <Field name="objectName" />
             <Field name="objectNameCurrency" />
             <Field name="objectNameLevel" />
@@ -238,6 +239,7 @@ const template = (configContext) => {
 
         <Field name="materialGroupList">
           <Field name="materialGroup">
+            <Field name="materialControlled" />
             <Field name="material" />
             <Field name="materialComponent" />
             <Field name="materialComponentNote" />


### PR DESCRIPTION
**What does this do?**
This updates the forms which were missing the controlled fields from 7.2. It also updates ordering of the fields so that the controlled field is display first in the row.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1397

This is something I discovered while adding public browser data through the template and realized I never updated the other forms to include these fields.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create a collectionobject using...
  * default template
  * timebasedmedia template
  * public browser template
* See that the controlled object name and controlled material fields exist and display first

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against core, not against this profile