### PR TITLE
DRYD-2008: Procedure > Acquisition > Create new Acquisition Description field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## V8.2.0
+
+v8.2.0 adds support for CollectionSpace 8.3, and requires cspace-ui version 10.2.0
+
+### Changes
+
+- Added the Acquisition description free text field (`acquisitionDescription`) to the record editor for Acquisitions.
+
 ## v8.1.0
 
 v8.1.0 adds support for CollectionSpace 8.2

--- a/src/plugins/recordTypes/acquisition/forms/default.jsx
+++ b/src/plugins/recordTypes/acquisition/forms/default.jsx
@@ -73,6 +73,8 @@ const template = (configContext) => {
               </InputTable>
             </Panel>
 
+            <Field name="acquisitionDescription" />
+
             <Field name="acquisitionReason" />
           </Col>
         </Cols>


### PR DESCRIPTION
**What does this do?**
Adds a new field, acquisition description, similar to https://github.com/collectionspace/cspace-ui-plugin-profile-lhmc.js/pull/31

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-2008

This is a field which is needed for an upcoming data migration.

**How should this be tested? Do these changes have associated tests?**
1. Run the devserver with the https://github.com/collectionspace/application/pull/334 and the https://github.com/collectionspace/cspace-ui.js/pull/332 (they should by now be merged to `develop` branches)
2. Create a new Acquisition
3. Populate the new field under Acquisition Information > Acquisition description
4. Save and reload to ensure the field populated
5. Use the AdvancedSearch for an Acquisition
6. Verify that the field shows up under the fields

**Dependencies for merging? Releasing to production?**
Should be released along with https://github.com/collectionspace/application/pull/334 https://github.com/collectionspace/cspace-ui.js/pull/332

**Has the application documentation been updated for these changes?**
Changelog has been updated

**Did someone actually run this code to verify it works?**
@spirosdi ran it locally